### PR TITLE
Improved PKGBUILD according to our standard

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,25 +2,28 @@
 # Contributor: echo -n 'YXh0bG9zIDxheHRsb3NAZ2V0Y3J5c3QuYWw+'     | base64 -d
 
 pkgname=jade-gui
+_pkgname=jadegui
 pkgver=1.5.0
-pkgrel=1
+pkgrel=2
 pkgdesc='Libadwaita based GUI front-end for Jade'
 license=('GPL3')
 arch=('any')
-url="https://github.com/crystal-linux/$pkgname"
+url="https://github.com/crystal-linux/${pkgname}"
 depends=('jade' 'openssl' 'flatpak')
-makedepends=('flatpak-builder' 'git')
-source=("jade-gui-v$pkgver-$pkgrel::git+${url}#tag=v$pkgver")
-sha256sums=('SKIP')
+makedepends=('flatpak-builder')
+source=("${pkgname}-${pkgver}::${url}/archive/v${pkgver}.tar.gz")
+sha256sums=('b1c8454d03ae322607f5af88b3bfb2dcde9bfd15642ba6e8adb0b8dbdab0d94e')
 
 build() {
-    cd "$srcdir/$pkgname-v$pkgver-$pkgrel"
+    cd "${srcdir}/${pkgname}-${pkgver}"
     flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
-    flatpak-builder --install-deps-from=flathub --repo=../build-repo --force-clean ../build-dir al.getcryst.jadegui.yml
-    flatpak build-bundle ../build-repo --runtime-repo=https://flathub.org/repo/flathub.flatpakrepo ../jade-gui.flatpak al.getcryst.jadegui
+    flatpak-builder --install-deps-from=flathub --repo=../build-repo --force-clean ../build-dir al.getcryst.${_pkgname}.yml
+    flatpak build-bundle ../build-repo --runtime-repo=https://flathub.org/repo/flathub.flatpakrepo ../${pkgname}.flatpak al.getcryst.${_pkgname}
 }
 
 package() {
-    install -Dm 0755 jade-gui.flatpak -t "$pkgdir/usr/share/jade-gui/"
-    install -Dm 0755 ../jade-gui -t "$pkgdir/usr/bin/"
+    cd "${srcdir}/${pkgname}-${pkgver}"
+    install -Dm 755 "${pkgname}.flatpak" "${pkgdir}/usr/share/${pkgname}/${pkgname}.flatpak"
+    install -Dm 755 "../${pkgname}" "$pkgdir/usr/bin/${pkgname}"
+    install -Dm 644 README.md "${pkgdir}/usr/share/doc/${pkgname}/README.md"
 }

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -24,6 +24,6 @@ build() {
 package() {
     cd "${srcdir}"
     install -Dm 755 "${pkgname}.flatpak" "${pkgdir}/usr/share/${pkgname}/${pkgname}.flatpak"
-    install -Dm 755 "../${pkgname}" "$pkgdir/usr/bin/${pkgname}"
+    install -Dm 755 "../${pkgname}" "${pkgdir}/usr/bin/${pkgname}"
     install -Dm 644 "${pkgname}-${pkgver}/README.md" "${pkgdir}/usr/share/doc/${pkgname}/README.md"
 }

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -22,8 +22,8 @@ build() {
 }
 
 package() {
-    cd "${srcdir}/${pkgname}-${pkgver}"
+    cd "${srcdir}"
     install -Dm 755 "${pkgname}.flatpak" "${pkgdir}/usr/share/${pkgname}/${pkgname}.flatpak"
     install -Dm 755 "../${pkgname}" "$pkgdir/usr/bin/${pkgname}"
-    install -Dm 644 README.md "${pkgdir}/usr/share/doc/${pkgname}/README.md"
+    install -Dm 644 "${pkgname}-${pkgver}/README.md" "${pkgdir}/usr/share/doc/${pkgname}/README.md"
 }


### PR DESCRIPTION
Hi,

Improvements for the `jade-gui` PKGBUILD.

- Switched all vars to `${var}` format.
- Used the `${pkgname}` var instead of `jade-gui`, created the `${_pkgname}` var to refer to `jadegui`.
- Replaced git sources by release's archive, added sha256sum integrity check accordingly, dropped `git` from `makedepends`.
- Added te README.md file to `usr/share/doc/jade-gui` (since it provides the build instructions).

What do you think?